### PR TITLE
Update dnasample 1 dm3 dataset dtype to int16

### DIFF
--- a/images/index.html
+++ b/images/index.html
@@ -180,7 +180,7 @@
         <td><a href="https://samples.scif.io/dnasample1.zip">dnasample1.zip</a></td>
         <td>Gatan DM3</td>
         <td>25,689,710 bytes</td>
-        <td>uint16</td>
+        <td>int16</td>
         <td>4096 x 4096</td>
         <td><a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0</a></td>
         <td><a href="http://www.engr.wisc.edu/mse/">Materials Science &amp; Engineering</a>, <a


### PR DESCRIPTION
When opening this dataset via bioformats (using pims), and opening it via [this python lib](https://github.com/nanobore/dm3) both result in int16 dtype. I'm not an expert with the dm3 format, so this should maybe be double-checked with other tools.